### PR TITLE
Update for Ink@0.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```sh
-$ npm install --save ink-progress-bar
+$ npm install ink-progress-bar
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ See [examples/basic.js](examples/basic.js) for an example app. Run it with `./ex
 
 ```jsx
 const {h} = require('ink');
-const ProgressBar = require('ink-progrss-bar');
+const ProgressBar = require('ink-progress-bar');
 
 <ProgressBar
 	char="x"
@@ -32,7 +32,7 @@ const ProgressBar = require('ink-progrss-bar');
 
 All props except the ones below are passed to `<Text>` as-is.
 
-### char
+### character
 
 Type: `string`<br>
 Default: `'█'`

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,7 +1,7 @@
 /* @jsx h */
 'use strict';
 
-const {h, mount, Component, Text} = require('ink');
+const {h, render, Component, Text} = require('ink');
 const ProgressBar = require('../src/progress-bar');
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -51,5 +51,4 @@ class ProgressApp extends Component {
   }
 }
 
-mount(<ProgressApp/>, process.stdout);
-
+render(<ProgressApp/>);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "blacklist": "^1.1.4",
-    "ink": "^0.1.2"
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -27,6 +27,7 @@
     "coveralls": "^2.13.1",
     "eslint-config-xo-react": "^0.13.0",
     "eslint-plugin-react": "^7.1.0",
+    "ink": "^0.2.1",
     "jest": "^20.0.4",
     "xo": "^0.18.2"
   },
@@ -53,9 +54,6 @@
     "plugins": [
       "react"
     ],
-    "rules": {
-      "react/prop-types": 0
-    },
     "settings": {
       "react": {
         "pragma": "h"

--- a/src/__tests__/progress-bar-test.js
+++ b/src/__tests__/progress-bar-test.js
@@ -1,7 +1,13 @@
 const ProgressBar = require('../progress-bar.js');
 
 const run = (columns, left, right) => ProgressBar.prototype.getString.call({
-  props: {columns, left, right, char: 'x'}
+  props: {
+    columns,
+    left,
+    right,
+    percent: 1,
+    character: 'x'
+  }
 });
 
 it(`has correct length`, () => {
@@ -11,4 +17,3 @@ it(`has correct length`, () => {
   const str2 = run(60, 10, 9);
   expect(str2.length).toBe(41);
 });
-

--- a/src/progress-bar.js
+++ b/src/progress-bar.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const PropTypes = require('prop-types');
 const blacklist = require('blacklist');
 const {Component, h, Text} = require('ink');
 
@@ -7,15 +8,11 @@ const PROPS = ['percent', 'left', 'right', 'columns', 'character'];
 
 class Bar extends Component {
   getString() {
-    const {
-      percent = 1,
-      left = 0,
-      right = 0,
-      character = '█'
-    } = this.props;
-    const screen = this.props.columns || process.stdout.columns || 80;
-    const space = screen - right - left;
+    const {percent, columns, left, right, character} = this.props;
+
+    const space = columns - right - left;
     const max = Math.min(Math.floor(space * percent), space);
+
     return character.repeat(max);
   }
 
@@ -25,5 +22,20 @@ class Bar extends Component {
   }
 }
 
-module.exports = Bar;
+Bar.defaultProps = {
+  columns: process.stdout.columns || 80,
+  percent: 1,
+  left: 0,
+  right: 0,
+  character: '█'
+};
 
+Bar.propTypes = {
+  columns: PropTypes.number,
+  percent: PropTypes.number,
+  left: PropTypes.number,
+  right: PropTypes.number,
+  character: PropTypes.string
+};
+
+module.exports = Bar;

--- a/src/progress-bar.js
+++ b/src/progress-bar.js
@@ -10,7 +10,8 @@ class Bar extends Component {
   getString() {
     const {percent, columns, left, right, character} = this.props;
 
-    const space = columns - right - left;
+    const screen = columns || process.stdout.columns || 80;
+    const space = screen - right - left;
     const max = Math.min(Math.floor(space * percent), space);
 
     return character.repeat(max);
@@ -23,7 +24,7 @@ class Bar extends Component {
 }
 
 Bar.defaultProps = {
-  columns: process.stdout.columns || 80,
+  columns: 0,
   percent: 1,
   left: 0,
   right: 0,


### PR DESCRIPTION
Ink@0.2.1 has just been released and it contains breaking changes. See https://github.com/vadimdemedes/ink/releases for more info.

PR updates this component for the latest Ink and contains some important fixes, like moving `ink` to `devDependencies`. 